### PR TITLE
Add JedisPool to Java quickstart

### DIFF
--- a/quickstart/java/redistest/src/main/java/example/demo/App.java
+++ b/quickstart/java/redistest/src/main/java/example/demo/App.java
@@ -1,25 +1,78 @@
 package example.demo;
 
 import redis.clients.jedis.Jedis;
-import redis.clients.jedis.JedisShardInfo;
+import redis.clients.jedis.JedisPool;
+import redis.clients.jedis.JedisPoolConfig;
+import redis.clients.jedis.Protocol;
 
 /**
  * Redis test
  *
  */
-public class App 
-{
-    public static void main( String[] args )
-    {
+public class App {
+    private static Object staticLock = new Object();
+    private static JedisPool pool;
+    private static String host;
+    private static int port;
+    private static String password;
+    private static JedisPoolConfig config;
 
-        boolean useSsl = true;
+    // Should be called exactly once during app startup logic.
+    public static void initializeSettings(String host, int port, String password) {
+        App.host = host;
+        App.port = port;
+        App.password = password;
+    }
+
+    public static JedisPool getPoolInstance() {
+        if (pool == null) { // avoid synchronization lock if initialization has already happened
+            synchronized(staticLock) {
+                if (pool == null) { // don't re-initialize if another thread beat us to it.
+                    JedisPoolConfig poolConfig = getPoolConfig();
+                    boolean useSsl = port == 6380 ? true : false;
+                    int db = 0;
+                    pool = new JedisPool(poolConfig, host, port, Protocol.DEFAULT_TIMEOUT, password, db, useSsl);
+                }
+            }
+        }
+        return pool;
+    }
+
+    public static JedisPoolConfig getPoolConfig() {
+        if (config == null) {
+            JedisPoolConfig poolConfig = new JedisPoolConfig();
+
+            // Each thread trying to access Redis needs its own Jedis instance from the pool.
+            // Using too small a value here can lead to performance problems, too big and you have wasted resources.
+            int maxConnections = 200;
+            poolConfig.setMaxTotal(maxConnections);
+            poolConfig.setMaxIdle(maxConnections);
+
+            // Using "false" here will make it easier to debug when your maxTotal/minIdle/etc settings need adjusting.
+            // Setting it to "true" will result better behavior when unexpected load hits in production
+            poolConfig.setBlockWhenExhausted(true);
+
+            // How long to wait before throwing when pool is exhausted
+            poolConfig.setMaxWaitMillis(JedisPoolConfig.DEFAULT_MAX_WAIT_MILLIS);
+
+            // This controls the number of connections that should be maintained for bursts of load.
+            // Increase this value when you see pool.getResource() taking a long time to complete under burst scenarios
+            poolConfig.setMinIdle(50);
+
+            config = poolConfig;
+        }
+
+        return config;
+    }
+
+    public static void main( String[] args ) {
         String cacheHostname = System.getenv("REDISCACHEHOSTNAME");
         String cachekey = System.getenv("REDISCACHEKEY");
 
         // Connect to the Azure Cache for Redis over the TLS/SSL port using the key.
-        JedisShardInfo shardInfo = new JedisShardInfo(cacheHostname, 6380, useSsl);
-        shardInfo.setPassword(cachekey); /* Use your access key. */
-        Jedis jedis = new Jedis(shardInfo);      
+        initializeSettings(cacheHostname, 6380, cachekey);
+        JedisPool jedisPool = getPoolInstance();
+        Jedis jedis = jedisPool.getResource();
 
         // Perform cache operations using the cache connection object...
 
@@ -43,5 +96,6 @@ public class App
         System.out.println( "Cache Response : " + jedis.clientList());
 
         jedis.close();
+        jedisPool.close();
     }
 }


### PR DESCRIPTION
## Purpose

For the Java Jedis quickstart, use `JedisPool` to provide the `Jedis`
instance so that the app is ready to scale up to multiple threads. The
general setup for `JedisPool` comes from a previously published
[gist][0].

This aligns the quickstart more closely with the ["Basic usage
example"][1] from the upstream Jedis docs.

Other changes:

Move a couple of punctuation characters to match the style used in the
Jedis source code.

[0]: https://gist.github.com/JonCole/925630df72be1351b21440625ff2671f#file-redis-samplecode-java-jedispool-java
[1]: https://github.com/redis/jedis/wiki/Getting-started/cd6eb0cebe4569291a1fc814192515ce6bd1c01c#basic-usage-example

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```