### PR TITLE
Add build pipeline definition

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,50 @@
+trigger:
+- main
+
+pr:
+- main
+
+pool:
+  vmImage: 'windows-latest'
+
+steps:
+- task: DotNetCoreCLI@2
+  displayName: 'Build ASP.NET Core quickstart'
+  continueOnError: true
+  inputs:
+    command: 'build'
+    workingDirectory: 'quickstart\aspnet-core\ContosoTeamStats'
+- task: NuGetCommand@2
+  continueOnError: true
+  displayName: 'NuGet restore ASP.NET quickstart'
+  inputs:
+    command: 'restore'
+    restoreSolution: 'quickstart\aspnet\*.sln' 
+- task: VSBuild@1
+  continueOnError: true
+  displayName: 'Build ASP.NET quickstart'
+  inputs:
+    solution: 'quickstart\aspnet\*.sln' 
+- task: DotNetCoreCLI@2
+  continueOnError: true
+  displayName: 'Build .NET Core quickstart'
+  inputs:
+    command: 'build'
+    workingDirectory: 'quickstart\dotnet-core'
+- task: NuGetCommand@2
+  continueOnError: true
+  displayName: 'NuGet restore .NET quickstart'
+  inputs:
+    command: 'restore'
+    restoreSolution: 'quickstart\dotnet\*.sln' 
+- task: VSBuild@1
+  continueOnError: true
+  displayName: 'Build .NET quickstart'
+  inputs:
+    solution: 'quickstart\dotnet\*.sln' 
+- task: Maven@3
+  continueOnError: true
+  displayName: 'Build Java quickstart'
+  inputs:
+    mavenPOMFile: 'quickstart\java\redistest\pom.xml'
+    goals: 'compile'


### PR DESCRIPTION
## Purpose

Add an initial Azure Pipelines build pipeline definition that builds the
.NET and Java quickstarts.

This will help with monitoring pull requests for build errors. It also
provides a place to run open source Component Governance on the
repository.

I verified that this pipeline builds all of the .NET and Java
quickstarts successfully. I also verified that the pipeline is eligible
to run the open source Component Governance step.

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[x] Other... Please describe: Continuous integration changes
```