### PR TITLE
Move away from Lazy<ConnectionMultiplexer> and use SemaphoreSlim, Async

### DIFF
--- a/quickstart/aspnet-core/ContosoTeamStats/Controllers/HomeController.cs
+++ b/quickstart/aspnet-core/ContosoTeamStats/Controllers/HomeController.cs
@@ -46,6 +46,11 @@ namespace ContosoTeamStats.Controllers
         {
             ViewBag.Message = "A simple example with Azure Cache for Redis on ASP.NET Core.";
 
+            if (Connection == null)
+            {
+                await InitializeAsync();
+            }
+
             IDatabase cache = await GetDatabaseAsync();
 
             // Perform cache operations using the cache object...
@@ -288,31 +293,19 @@ namespace ContosoTeamStats.Controllers
             }
         }
 
-        public static async Task<IDatabase> GetDatabaseAsync()
+        public static Task<IDatabase> GetDatabaseAsync()
         {
-            if (Connection == null)
-            {
-                await InitializeAsync();
-            }
-            return await BasicRetryAsync(() => Connection.GetDatabase());
+            return BasicRetryAsync(() => Connection.GetDatabase());
         }
 
-        public static async Task<System.Net.EndPoint[]> GetEndPointsAsync()
+        public static Task<System.Net.EndPoint[]> GetEndPointsAsync()
         {
-            if (Connection == null)
-            {
-                await InitializeAsync();
-            }
-            return await BasicRetryAsync(() => Connection.GetEndPoints());
+            return BasicRetryAsync(() => Connection.GetEndPoints());
         }
 
-        public static async Task<IServer> GetServerAsync(string host, int port)
+        public static Task<IServer> GetServerAsync(string host, int port)
         {
-            if (Connection == null)
-            {
-                await InitializeAsync();
-            }
-            return await BasicRetryAsync(() => Connection.GetServer(host, port));
+            return BasicRetryAsync(() => Connection.GetServer(host, port));
         }
     }
 }

--- a/quickstart/aspnet-core/ContosoTeamStats/Controllers/HomeController.cs
+++ b/quickstart/aspnet-core/ContosoTeamStats/Controllers/HomeController.cs
@@ -76,7 +76,7 @@ namespace ContosoTeamStats.Controllers
             StringBuilder sb = new StringBuilder();
             var endpoint = (System.Net.DnsEndPoint)(await GetEndPointsAsync())[0];
             IServer server = await GetServerAsync(endpoint.Host, endpoint.Port);
-            ClientInfo[] clients = server.ClientList();
+            ClientInfo[] clients = await server.ClientListAsync();
 
             sb.AppendLine("Cache response :");
             foreach (ClientInfo client in clients)

--- a/quickstart/aspnet/ContosoTeamStats/Controllers/HomeController.cs
+++ b/quickstart/aspnet/ContosoTeamStats/Controllers/HomeController.cs
@@ -4,6 +4,7 @@ using System.Configuration;
 using System.Net.Sockets;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 using System.Web.Mvc;
 
 namespace ContosoTeamStats.Controllers
@@ -29,11 +30,11 @@ namespace ContosoTeamStats.Controllers
             return View();
         }
 
-        public ActionResult RedisCache()
+        public async Task<ActionResult> RedisCache()
         {
             ViewBag.Message = "A simple example with Azure Cache for Redis on ASP.NET.";
 
-            IDatabase cache = GetDatabase();
+            IDatabase cache = await GetDatabaseAsync();
 
             // Perform cache operations using the cache object...
 
@@ -56,9 +57,9 @@ namespace ContosoTeamStats.Controllers
             // Note that this requires allowAdmin=true in the connection string
             ViewBag.command5 = "CLIENT LIST";
             StringBuilder sb = new StringBuilder();
-            var endpoint = (System.Net.DnsEndPoint)GetEndPoints()[0];
-            IServer server = GetServer(endpoint.Host, endpoint.Port);
-            ClientInfo[] clients = server.ClientList();
+            var endpoint = (System.Net.DnsEndPoint)(await GetEndPointsAsync())[0];
+            IServer server = await GetServerAsync(endpoint.Host, endpoint.Port);
+            ClientInfo[] clients = await server.ClientListAsync();
 
             sb.AppendLine("Cache response :");
             foreach (ClientInfo client in clients)
@@ -94,33 +95,23 @@ namespace ContosoTeamStats.Controllers
         public static TimeSpan RestartConnectionTimeout => TimeSpan.FromSeconds(15);
 
         public static int RetryMaxAttempts => 5;
-        
-        public static ConnectionMultiplexer Connection
-        {
-            get
-            {
-                if (_connection == null)
-                {
-                    Initialize();
-                }
-                return _connection;
-            }
-        }
 
-        public static void Initialize()
+        public static ConnectionMultiplexer Connection { get { return _connection; } }
+
+        public static async Task InitializeAsync()
         {
             if (_didInitialize)
             {
                 throw new InvalidOperationException("Cannot initialize more than once.");
             }
 
-            _connection = CreateConnection();
+            _connection = await CreateConnectionAsync();
             _didInitialize = true;
         }
 
         // This method may return null if it fails to acquire the semaphore in time.
         // Use the return value to update the "connection" field
-        private static ConnectionMultiplexer CreateConnection()
+        private static async Task<ConnectionMultiplexer> CreateConnectionAsync()
         {
             if (_connection != null)
             {
@@ -130,7 +121,7 @@ namespace ContosoTeamStats.Controllers
 
             try
             {
-                _initSemaphore.Wait(RestartConnectionTimeout);
+                await _initSemaphore.WaitAsync(RestartConnectionTimeout);
             }
             catch
             {
@@ -149,7 +140,7 @@ namespace ContosoTeamStats.Controllers
 
                 // Otherwise, we really need to create a new connection.
                 string cacheConnection = ConfigurationManager.AppSettings["CacheConnection"].ToString();
-                return ConnectionMultiplexer.Connect(cacheConnection);
+                return await ConnectionMultiplexer.ConnectAsync(cacheConnection);
             }
             finally
             {
@@ -157,7 +148,7 @@ namespace ContosoTeamStats.Controllers
             }
         }
 
-        private static void CloseConnection(ConnectionMultiplexer oldConnection)
+        private static async Task CloseConnectionAsync(ConnectionMultiplexer oldConnection)
         {
             if (oldConnection == null)
             {
@@ -165,7 +156,7 @@ namespace ContosoTeamStats.Controllers
             }
             try
             {
-                oldConnection.Close();
+                await oldConnection.CloseAsync();
             }
             catch (Exception)
             {
@@ -173,26 +164,25 @@ namespace ContosoTeamStats.Controllers
             }
         }
 
-
         /// <summary>
         /// Force a new ConnectionMultiplexer to be created.
         /// NOTES:
-        ///     1. Users of the ConnectionMultiplexer MUST handle ObjectDisposedExceptions, which can now happen as a result of calling ForceReconnect().
-        ///     2. Call ForceReconnect() for RedisConnectionExceptions and RedisSocketExceptions. You can also call it for RedisTimeoutExceptions,
+        ///     1. Users of the ConnectionMultiplexer MUST handle ObjectDisposedExceptions, which can now happen as a result of calling ForceReconnectAsync().
+        ///     2. Call ForceReconnectAsync() for RedisConnectionExceptions and RedisSocketExceptions. You can also call it for RedisTimeoutExceptions,
         ///         but only if you're using generous ReconnectMinInterval and ReconnectErrorThreshold. Otherwise, establishing new connections can cause
         ///         a cascade failure on a server that's timing out because it's already overloaded.
         ///     3. The code will:
         ///         a. wait to reconnect for at least the "ReconnectErrorThreshold" time of repeated errors before actually reconnecting
         ///         b. not reconnect more frequently than configured in "ReconnectMinInterval"
         /// </summary>
-        public static void ForceReconnect()
+        public static async Task ForceReconnectAsync()
         {
             var utcNow = DateTimeOffset.UtcNow;
             long previousTicks = Interlocked.Read(ref _lastReconnectTicks);
             var previousReconnectTime = new DateTimeOffset(previousTicks, TimeSpan.Zero);
             TimeSpan elapsedSinceLastReconnect = utcNow - previousReconnectTime;
 
-            // If multiple threads call ForceReconnect at the same time, we only want to honor one of them.
+            // If multiple threads call ForceReconnectAsync at the same time, we only want to honor one of them.
             if (elapsedSinceLastReconnect < ReconnectMinInterval)
             {
                 return;
@@ -200,12 +190,12 @@ namespace ContosoTeamStats.Controllers
 
             try
             {
-                _reconnectSemaphore.Wait(RestartConnectionTimeout);
+                await _reconnectSemaphore.WaitAsync(RestartConnectionTimeout);
             }
             catch
             {
                 // If we fail to enter the semaphore, then it is possible that another thread has already done so.
-                // ForceReconnect() can be retried while connectivity problems persist.
+                // ForceReconnectAsync() can be retried while connectivity problems persist.
                 return;
             }
 
@@ -246,9 +236,9 @@ namespace ContosoTeamStats.Controllers
                 _previousErrorTime = DateTimeOffset.MinValue;
 
                 ConnectionMultiplexer oldConnection = _connection;
-                CloseConnection(oldConnection);
+                await CloseConnectionAsync(oldConnection);
                 _connection = null;
-                _connection = CreateConnection();
+                _connection = await CreateConnectionAsync();
                 Interlocked.Exchange(ref _lastReconnectTicks, utcNow.UtcTicks);
             }
             finally
@@ -259,7 +249,7 @@ namespace ContosoTeamStats.Controllers
 
         // In real applications, consider using a framework such as
         // Polly to make it easier to customize the retry approach.
-        private static T BasicRetry<T>(Func<T> func)
+        private static async Task<T> BasicRetryAsync<T>(Func<T> func)
         {
             int reconnectRetry = 0;
             int disposedRetry = 0;
@@ -275,7 +265,7 @@ namespace ContosoTeamStats.Controllers
                     reconnectRetry++;
                     if (reconnectRetry > RetryMaxAttempts)
                         throw;
-                    ForceReconnect();
+                    await ForceReconnectAsync();
                 }
                 catch (ObjectDisposedException)
                 {
@@ -286,19 +276,31 @@ namespace ContosoTeamStats.Controllers
             }
         }
 
-        public static IDatabase GetDatabase()
+        public static async Task<IDatabase> GetDatabaseAsync()
         {
-            return BasicRetry(() => Connection.GetDatabase());
+            if (Connection == null)
+            {
+                await InitializeAsync();
+            }
+            return await BasicRetryAsync(() => Connection.GetDatabase());
         }
 
-        public static System.Net.EndPoint[] GetEndPoints()
+        public static async Task<System.Net.EndPoint[]> GetEndPointsAsync()
         {
-            return BasicRetry(() => Connection.GetEndPoints());
+            if (Connection == null)
+            {
+                await InitializeAsync();
+            }
+            return await BasicRetryAsync(() => Connection.GetEndPoints());
         }
 
-        public static IServer GetServer(string host, int port)
+        public static async Task<IServer> GetServerAsync(string host, int port)
         {
-            return BasicRetry(() => Connection.GetServer(host, port));
+            if (Connection == null)
+            {
+                await InitializeAsync();
+            }
+            return await BasicRetryAsync(() => Connection.GetServer(host, port));
         }
     }
 }

--- a/quickstart/aspnet/ContosoTeamStats/Controllers/HomeController.cs
+++ b/quickstart/aspnet/ContosoTeamStats/Controllers/HomeController.cs
@@ -71,114 +71,189 @@ namespace ContosoTeamStats.Controllers
             return View();
         }
 
-        private static long lastReconnectTicks = DateTimeOffset.MinValue.UtcTicks;
-        private static DateTimeOffset firstErrorTime = DateTimeOffset.MinValue;
-        private static DateTimeOffset previousErrorTime = DateTimeOffset.MinValue;
+        private static long _lastReconnectTicks = DateTimeOffset.MinValue.UtcTicks;
+        private static DateTimeOffset _firstErrorTime = DateTimeOffset.MinValue;
+        private static DateTimeOffset _previousErrorTime = DateTimeOffset.MinValue;
 
-        private static readonly object reconnectLock = new object();
+        private static SemaphoreSlim _reconnectSemaphore = new SemaphoreSlim(initialCount: 1, maxCount: 1);
+        private static SemaphoreSlim _initSemaphore = new SemaphoreSlim(initialCount: 1, maxCount: 1);
+
+        private static ConnectionMultiplexer _connection;
+        private static bool _didInitialize = false;
 
         // In general, let StackExchange.Redis handle most reconnects,
         // so limit the frequency of how often ForceReconnect() will
         // actually reconnect.
-        public static TimeSpan ReconnectMinFrequency => TimeSpan.FromSeconds(60);
+        public static TimeSpan ReconnectMinInterval => TimeSpan.FromSeconds(60);
 
         // If errors continue for longer than the below threshold, then the
         // multiplexer seems to not be reconnecting, so ForceReconnect() will
         // re-create the multiplexer.
         public static TimeSpan ReconnectErrorThreshold => TimeSpan.FromSeconds(30);
 
+        public static TimeSpan RestartConnectionTimeout => TimeSpan.FromSeconds(15);
+
         public static int RetryMaxAttempts => 5;
-
-        private static Lazy<ConnectionMultiplexer> lazyConnection = CreateConnection();
-
+        
         public static ConnectionMultiplexer Connection
         {
             get
             {
-                return lazyConnection.Value;
+                if (_connection == null)
+                {
+                    Initialize();
+                }
+                return _connection;
             }
         }
 
-        private static Lazy<ConnectionMultiplexer> CreateConnection()
+        public static void Initialize()
         {
-            return new Lazy<ConnectionMultiplexer>(() =>
+            if (_didInitialize)
             {
-                string cacheConnection = ConfigurationManager.AppSettings["CacheConnection"].ToString();
-                return ConnectionMultiplexer.Connect(cacheConnection);
-            });
+                throw new InvalidOperationException("Cannot initialize more than once.");
+            }
+
+            _connection = CreateConnection();
+            _didInitialize = true;
         }
 
-        private static void CloseConnection(Lazy<ConnectionMultiplexer> oldConnection)
+        // This method may return null if it fails to acquire the semaphore in time.
+        // Use the return value to update the "connection" field
+        private static ConnectionMultiplexer CreateConnection()
         {
-            if (oldConnection == null)
-                return;
+            if (_connection != null)
+            {
+                // If we already have a good connection, let's re-use it
+                return _connection;
+            }
 
             try
             {
-                oldConnection.Value.Close();
+                _initSemaphore.Wait(RestartConnectionTimeout);
+            }
+            catch
+            {
+                // We failed to enter the semaphore in the given amount of time. Connection will either be null, or have a value that was created by another thread.
+                return _connection;
+            }
+
+            // We entered the semaphore successfully.
+            try
+            {
+                if (_connection != null)
+                {
+                    // Another thread must have finished creating a new connection while we were waiting to enter the semaphore. Let's use it
+                    return _connection;
+                }
+
+                // Otherwise, we really need to create a new connection.
+                string cacheConnection = ConfigurationManager.AppSettings["CacheConnection"].ToString();
+                return ConnectionMultiplexer.Connect(cacheConnection);
+            }
+            finally
+            {
+                _initSemaphore.Release();
+            }
+        }
+
+        private static void CloseConnection(ConnectionMultiplexer oldConnection)
+        {
+            if (oldConnection == null)
+            {
+                return;
+            }
+            try
+            {
+                oldConnection.Close();
             }
             catch (Exception)
             {
-                // Example error condition: if accessing oldConnection.Value causes a connection attempt and that fails.
+                // Ignore any errors from the oldConnection
             }
         }
+
 
         /// <summary>
         /// Force a new ConnectionMultiplexer to be created.
         /// NOTES:
         ///     1. Users of the ConnectionMultiplexer MUST handle ObjectDisposedExceptions, which can now happen as a result of calling ForceReconnect().
-        ///     2. Don't call ForceReconnect for Timeouts, just for RedisConnectionExceptions or SocketExceptions.
-        ///     3. Call this method every time you see a connection exception. The code will:
+        ///     2. Call ForceReconnect() for RedisConnectionExceptions and RedisSocketExceptions. You can also call it for RedisTimeoutExceptions,
+        ///         but only if you're using generous ReconnectMinInterval and ReconnectErrorThreshold. Otherwise, establishing new connections can cause
+        ///         a cascade failure on a server that's timing out because it's already overloaded.
+        ///     3. The code will:
         ///         a. wait to reconnect for at least the "ReconnectErrorThreshold" time of repeated errors before actually reconnecting
-        ///         b. not reconnect more frequently than configured in "ReconnectMinFrequency"
+        ///         b. not reconnect more frequently than configured in "ReconnectMinInterval"
         /// </summary>
         public static void ForceReconnect()
         {
             var utcNow = DateTimeOffset.UtcNow;
-            long previousTicks = Interlocked.Read(ref lastReconnectTicks);
+            long previousTicks = Interlocked.Read(ref _lastReconnectTicks);
             var previousReconnectTime = new DateTimeOffset(previousTicks, TimeSpan.Zero);
             TimeSpan elapsedSinceLastReconnect = utcNow - previousReconnectTime;
 
             // If multiple threads call ForceReconnect at the same time, we only want to honor one of them.
-            if (elapsedSinceLastReconnect < ReconnectMinFrequency)
+            if (elapsedSinceLastReconnect < ReconnectMinInterval)
+            {
                 return;
+            }
 
-            lock (reconnectLock)
+            try
+            {
+                _reconnectSemaphore.Wait(RestartConnectionTimeout);
+            }
+            catch
+            {
+                // If we fail to enter the semaphore, then it is possible that another thread has already done so.
+                // ForceReconnect() can be retried while connectivity problems persist.
+                return;
+            }
+
+            try
             {
                 utcNow = DateTimeOffset.UtcNow;
                 elapsedSinceLastReconnect = utcNow - previousReconnectTime;
 
-                if (firstErrorTime == DateTimeOffset.MinValue)
+                if (_firstErrorTime == DateTimeOffset.MinValue)
                 {
                     // We haven't seen an error since last reconnect, so set initial values.
-                    firstErrorTime = utcNow;
-                    previousErrorTime = utcNow;
+                    _firstErrorTime = utcNow;
+                    _previousErrorTime = utcNow;
                     return;
                 }
 
-                if (elapsedSinceLastReconnect < ReconnectMinFrequency)
+                if (elapsedSinceLastReconnect < ReconnectMinInterval)
+                {
                     return; // Some other thread made it through the check and the lock, so nothing to do.
+                }
 
-                TimeSpan elapsedSinceFirstError = utcNow - firstErrorTime;
-                TimeSpan elapsedSinceMostRecentError = utcNow - previousErrorTime;
+                TimeSpan elapsedSinceFirstError = utcNow - _firstErrorTime;
+                TimeSpan elapsedSinceMostRecentError = utcNow - _previousErrorTime;
 
                 bool shouldReconnect =
                     elapsedSinceFirstError >= ReconnectErrorThreshold // Make sure we gave the multiplexer enough time to reconnect on its own if it could.
                     && elapsedSinceMostRecentError <= ReconnectErrorThreshold; // Make sure we aren't working on stale data (e.g. if there was a gap in errors, don't reconnect yet).
 
                 // Update the previousErrorTime timestamp to be now (e.g. this reconnect request).
-                previousErrorTime = utcNow;
+                _previousErrorTime = utcNow;
 
                 if (!shouldReconnect)
+                {
                     return;
+                }
 
-                firstErrorTime = DateTimeOffset.MinValue;
-                previousErrorTime = DateTimeOffset.MinValue;
+                _firstErrorTime = DateTimeOffset.MinValue;
+                _previousErrorTime = DateTimeOffset.MinValue;
 
-                Lazy<ConnectionMultiplexer> oldConnection = lazyConnection;
+                ConnectionMultiplexer oldConnection = _connection;
                 CloseConnection(oldConnection);
-                lazyConnection = CreateConnection();
-                Interlocked.Exchange(ref lastReconnectTicks, utcNow.UtcTicks);
+                _connection = null;
+                _connection = CreateConnection();
+                Interlocked.Exchange(ref _lastReconnectTicks, utcNow.UtcTicks);
+            }
+            finally
+            {
+                _reconnectSemaphore.Release();
             }
         }
 

--- a/quickstart/aspnet/ContosoTeamStats/Controllers/HomeController.cs
+++ b/quickstart/aspnet/ContosoTeamStats/Controllers/HomeController.cs
@@ -34,6 +34,11 @@ namespace ContosoTeamStats.Controllers
         {
             ViewBag.Message = "A simple example with Azure Cache for Redis on ASP.NET.";
 
+            if (Connection == null)
+            {
+                await InitializeAsync();
+            }
+
             IDatabase cache = await GetDatabaseAsync();
 
             // Perform cache operations using the cache object...
@@ -276,31 +281,19 @@ namespace ContosoTeamStats.Controllers
             }
         }
 
-        public static async Task<IDatabase> GetDatabaseAsync()
+        public static Task<IDatabase> GetDatabaseAsync()
         {
-            if (Connection == null)
-            {
-                await InitializeAsync();
-            }
-            return await BasicRetryAsync(() => Connection.GetDatabase());
+            return BasicRetryAsync(() => Connection.GetDatabase());
         }
 
-        public static async Task<System.Net.EndPoint[]> GetEndPointsAsync()
+        public static Task<System.Net.EndPoint[]> GetEndPointsAsync()
         {
-            if (Connection == null)
-            {
-                await InitializeAsync();
-            }
-            return await BasicRetryAsync(() => Connection.GetEndPoints());
+            return BasicRetryAsync(() => Connection.GetEndPoints());
         }
 
-        public static async Task<IServer> GetServerAsync(string host, int port)
+        public static Task<IServer> GetServerAsync(string host, int port)
         {
-            if (Connection == null)
-            {
-                await InitializeAsync();
-            }
-            return await BasicRetryAsync(() => Connection.GetServer(host, port));
+            return BasicRetryAsync(() => Connection.GetServer(host, port));
         }
     }
 }

--- a/quickstart/dotnet-core/Program.cs
+++ b/quickstart/dotnet-core/Program.cs
@@ -4,6 +4,7 @@ using StackExchange.Redis;
 using System;
 using System.Net.Sockets;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace Redistest
 {
@@ -24,130 +25,189 @@ namespace Redistest
     class Program
     {
         private static IConfigurationRoot Configuration { get; set; }
-        const string SecretName = "CacheConnection";
+        private static long _lastReconnectTicks = DateTimeOffset.MinValue.UtcTicks;
+        private static DateTimeOffset _firstErrorTime = DateTimeOffset.MinValue;
+        private static DateTimeOffset _previousErrorTime = DateTimeOffset.MinValue;
 
-        private static long lastReconnectTicks = DateTimeOffset.MinValue.UtcTicks;
-        private static DateTimeOffset firstErrorTime = DateTimeOffset.MinValue;
-        private static DateTimeOffset previousErrorTime = DateTimeOffset.MinValue;
+        private static SemaphoreSlim _reconnectSemaphore = new SemaphoreSlim(initialCount: 1, maxCount: 1);
+        private static SemaphoreSlim _initSemaphore = new SemaphoreSlim(initialCount: 1, maxCount: 1);
 
-        private static readonly object reconnectLock = new object();
+        private static ConnectionMultiplexer _connection;
+        private static bool _didInitialize = false;
 
         // In general, let StackExchange.Redis handle most reconnects,
         // so limit the frequency of how often ForceReconnect() will
         // actually reconnect.
-        public static TimeSpan ReconnectMinFrequency => TimeSpan.FromSeconds(60);
+        public static TimeSpan ReconnectMinInterval => TimeSpan.FromSeconds(60);
 
         // If errors continue for longer than the below threshold, then the
         // multiplexer seems to not be reconnecting, so ForceReconnect() will
         // re-create the multiplexer.
         public static TimeSpan ReconnectErrorThreshold => TimeSpan.FromSeconds(30);
 
+        public static TimeSpan RestartConnectionTimeout => TimeSpan.FromSeconds(15);
+
         public static int RetryMaxAttempts => 5;
+        
+        public static ConnectionMultiplexer Connection { get { return _connection; } }
 
-        private static Lazy<ConnectionMultiplexer> lazyConnection = CreateConnection();
-
-        public static ConnectionMultiplexer Connection
+        private static async Task InitializeAsync()
         {
-            get
+            if (_didInitialize)
             {
-                return lazyConnection.Value;
+                throw new InvalidOperationException("Cannot initialize more than once.");
             }
-        }
 
-        private static void InitializeConfiguration()
-        {
             var builder = new ConfigurationBuilder()
                 .AddUserSecrets<Program>();
 
             Configuration = builder.Build();
+            _connection = await CreateConnectionAsync();
+            _didInitialize = true;
+
         }
 
-        private static Lazy<ConnectionMultiplexer> CreateConnection()
+        // This method may return null if it fails to acquire the semaphore in time.
+        // Use the return value to update the "connection" field
+        private static async Task<ConnectionMultiplexer> CreateConnectionAsync()
         {
-            return new Lazy<ConnectionMultiplexer>(() =>
+            if (_connection != null)
             {
-                string cacheConnection = Configuration[SecretName];
-                return ConnectionMultiplexer.Connect(cacheConnection);
-            });
-        }
-
-        private static void CloseConnection(Lazy<ConnectionMultiplexer> oldConnection)
-        {
-            if (oldConnection == null)
-                return;
+                // If we already have a good connection, let's re-use it
+                return _connection;
+            }
 
             try
             {
-                oldConnection.Value.Close();
+                await _initSemaphore.WaitAsync(RestartConnectionTimeout);
+            }
+            catch
+            {
+                // We failed to enter the semaphore in the given amount of time. Connection will either be null, or have a value that was created by another thread.
+                return _connection;
+            }
+
+            // We entered the semaphore successfully.
+            try
+            {
+                if (_connection != null)
+                {
+                    // Another thread must have finished creating a new connection while we were waiting to enter the semaphore. Let's use it
+                    return _connection;
+                }
+
+                // Otherwise, we really need to create a new connection.
+                string cacheConnection = Configuration["CacheConnection"].ToString();
+                return await ConnectionMultiplexer.ConnectAsync(cacheConnection);
+            }
+            finally
+            {
+                _initSemaphore.Release();
+            }
+        }
+
+        private static async Task CloseConnectionAsync(ConnectionMultiplexer oldConnection)
+        {
+            if (oldConnection == null)
+            {
+                return;
+            }
+            try
+            {
+                await oldConnection.CloseAsync();
             }
             catch (Exception)
             {
-                // Example error condition: if accessing oldConnection.Value causes a connection attempt and that fails.
+                // Ignore any errors from the oldConnection
             }
         }
 
         /// <summary>
         /// Force a new ConnectionMultiplexer to be created.
         /// NOTES:
-        ///     1. Users of the ConnectionMultiplexer MUST handle ObjectDisposedExceptions, which can now happen as a result of calling ForceReconnect().
-        ///     2. Don't call ForceReconnect for Timeouts, just for RedisConnectionExceptions or SocketExceptions.
-        ///     3. Call this method every time you see a connection exception. The code will:
+        ///     1. Users of the ConnectionMultiplexer MUST handle ObjectDisposedExceptions, which can now happen as a result of calling ForceReconnectAsync().
+        ///     2. Call ForceReconnectAsync() for RedisConnectionExceptions and RedisSocketExceptions. You can also call it for RedisTimeoutExceptions,
+        ///         but only if you're using generous ReconnectMinInterval and ReconnectErrorThreshold. Otherwise, establishing new connections can cause
+        ///         a cascade failure on a server that's timing out because it's already overloaded.
+        ///     3. The code will:
         ///         a. wait to reconnect for at least the "ReconnectErrorThreshold" time of repeated errors before actually reconnecting
-        ///         b. not reconnect more frequently than configured in "ReconnectMinFrequency"
+        ///         b. not reconnect more frequently than configured in "ReconnectMinInterval"
         /// </summary>
-        public static void ForceReconnect()
+        public static async Task ForceReconnectAsync()
         {
             var utcNow = DateTimeOffset.UtcNow;
-            long previousTicks = Interlocked.Read(ref lastReconnectTicks);
+            long previousTicks = Interlocked.Read(ref _lastReconnectTicks);
             var previousReconnectTime = new DateTimeOffset(previousTicks, TimeSpan.Zero);
             TimeSpan elapsedSinceLastReconnect = utcNow - previousReconnectTime;
 
-            // If multiple threads call ForceReconnect at the same time, we only want to honor one of them.
-            if (elapsedSinceLastReconnect < ReconnectMinFrequency)
+            // If multiple threads call ForceReconnectAsync at the same time, we only want to honor one of them.
+            if (elapsedSinceLastReconnect < ReconnectMinInterval)
+            {
                 return;
+            }
 
-            lock (reconnectLock)
+            try
+            {
+                await _reconnectSemaphore.WaitAsync(RestartConnectionTimeout);
+            }
+            catch
+            {
+                // If we fail to enter the semaphore, then it is possible that another thread has already done so.
+                // ForceReconnectAsync() can be retried while connectivity problems persist.
+                return;
+            }
+
+            try
             {
                 utcNow = DateTimeOffset.UtcNow;
                 elapsedSinceLastReconnect = utcNow - previousReconnectTime;
 
-                if (firstErrorTime == DateTimeOffset.MinValue)
+                if (_firstErrorTime == DateTimeOffset.MinValue)
                 {
                     // We haven't seen an error since last reconnect, so set initial values.
-                    firstErrorTime = utcNow;
-                    previousErrorTime = utcNow;
+                    _firstErrorTime = utcNow;
+                    _previousErrorTime = utcNow;
                     return;
                 }
 
-                if (elapsedSinceLastReconnect < ReconnectMinFrequency)
+                if (elapsedSinceLastReconnect < ReconnectMinInterval)
+                {
                     return; // Some other thread made it through the check and the lock, so nothing to do.
+                }
 
-                TimeSpan elapsedSinceFirstError = utcNow - firstErrorTime;
-                TimeSpan elapsedSinceMostRecentError = utcNow - previousErrorTime;
+                TimeSpan elapsedSinceFirstError = utcNow - _firstErrorTime;
+                TimeSpan elapsedSinceMostRecentError = utcNow - _previousErrorTime;
 
                 bool shouldReconnect =
                     elapsedSinceFirstError >= ReconnectErrorThreshold // Make sure we gave the multiplexer enough time to reconnect on its own if it could.
                     && elapsedSinceMostRecentError <= ReconnectErrorThreshold; // Make sure we aren't working on stale data (e.g. if there was a gap in errors, don't reconnect yet).
 
                 // Update the previousErrorTime timestamp to be now (e.g. this reconnect request).
-                previousErrorTime = utcNow;
+                _previousErrorTime = utcNow;
 
                 if (!shouldReconnect)
+                {
                     return;
+                }
 
-                firstErrorTime = DateTimeOffset.MinValue;
-                previousErrorTime = DateTimeOffset.MinValue;
+                _firstErrorTime = DateTimeOffset.MinValue;
+                _previousErrorTime = DateTimeOffset.MinValue;
 
-                Lazy<ConnectionMultiplexer> oldConnection = lazyConnection;
-                CloseConnection(oldConnection);
-                lazyConnection = CreateConnection();
-                Interlocked.Exchange(ref lastReconnectTicks, utcNow.UtcTicks);
+                ConnectionMultiplexer oldConnection = _connection;
+                await CloseConnectionAsync(oldConnection);
+                _connection = null;
+                _connection = await CreateConnectionAsync();
+                Interlocked.Exchange(ref _lastReconnectTicks, utcNow.UtcTicks);
+            }
+            finally
+            {
+                _reconnectSemaphore.Release();
             }
         }
 
         // In real applications, consider using a framework such as
         // Polly to make it easier to customize the retry approach.
-        private static T BasicRetry<T>(Func<T> func)
+        private static async Task<T> BasicRetryAsync<T>(Func<T> func)
         {
             int reconnectRetry = 0;
             int disposedRetry = 0;
@@ -163,7 +223,7 @@ namespace Redistest
                     reconnectRetry++;
                     if (reconnectRetry > RetryMaxAttempts)
                         throw;
-                    ForceReconnect();
+                    await ForceReconnectAsync();
                 }
                 catch (ObjectDisposedException)
                 {
@@ -174,26 +234,26 @@ namespace Redistest
             }
         }
 
-        public static IDatabase GetDatabase()
+        public static Task<IDatabase> GetDatabaseAsync()
         {
-            return BasicRetry(() => Connection.GetDatabase());
+            return BasicRetryAsync(() => Connection.GetDatabase());
         }
 
-        public static System.Net.EndPoint[] GetEndPoints()
+        public static Task<System.Net.EndPoint[]> GetEndPointsAsync()
         {
-            return BasicRetry(() => Connection.GetEndPoints());
+            return BasicRetryAsync(() => Connection.GetEndPoints());
         }
 
-        public static IServer GetServer(string host, int port)
+        public static Task<IServer> GetServerAsync(string host, int port)
         {
-            return BasicRetry(() => Connection.GetServer(host, port));
+            return BasicRetryAsync(() => Connection.GetServer(host, port));
         }
 
-        static void Main(string[] args)
+        static async Task Main(string[] args)
         {
-            InitializeConfiguration();
+            await InitializeAsync();
 
-            IDatabase cache = GetDatabase();
+            IDatabase cache = await GetDatabaseAsync();
 
             // Perform cache operations using the cache object...
 
@@ -220,9 +280,9 @@ namespace Redistest
             // Note that this requires allowAdmin=true in the connection string
             cacheCommand = "CLIENT LIST";
             Console.WriteLine("\nCache command  : " + cacheCommand);
-            var endpoint = (System.Net.DnsEndPoint)GetEndPoints()[0];
-            IServer server = GetServer(endpoint.Host, endpoint.Port);
-            ClientInfo[] clients = server.ClientList();
+            var endpoint = (System.Net.DnsEndPoint)(await GetEndPointsAsync())[0];
+            IServer server = await GetServerAsync(endpoint.Host, endpoint.Port);
+            ClientInfo[] clients = await server.ClientListAsync();
 
             Console.WriteLine("Cache response :");
             foreach (ClientInfo client in clients)
@@ -242,7 +302,7 @@ namespace Redistest
             Console.WriteLine("\tEmployee.Id   : " + e007FromCache.Id);
             Console.WriteLine("\tEmployee.Age  : " + e007FromCache.Age + "\n");
 
-            CloseConnection(lazyConnection);
+            await CloseConnectionAsync(_connection);
         }
     }
 }

--- a/quickstart/dotnet/Redistest/Program.cs
+++ b/quickstart/dotnet/Redistest/Program.cs
@@ -4,6 +4,7 @@ using System;
 using System.Configuration;
 using System.Net.Sockets;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace Redistest
 {
@@ -23,120 +24,185 @@ namespace Redistest
 
     class Program
     {
-        private static long lastReconnectTicks = DateTimeOffset.MinValue.UtcTicks;
-        private static DateTimeOffset firstErrorTime = DateTimeOffset.MinValue;
-        private static DateTimeOffset previousErrorTime = DateTimeOffset.MinValue;
+        private static long _lastReconnectTicks = DateTimeOffset.MinValue.UtcTicks;
+        private static DateTimeOffset _firstErrorTime = DateTimeOffset.MinValue;
+        private static DateTimeOffset _previousErrorTime = DateTimeOffset.MinValue;
 
-        private static readonly object reconnectLock = new object();
+        private static SemaphoreSlim _reconnectSemaphore = new SemaphoreSlim(initialCount: 1, maxCount: 1);
+        private static SemaphoreSlim _initSemaphore = new SemaphoreSlim(initialCount: 1, maxCount: 1);
+
+        private static ConnectionMultiplexer _connection;
+        private static bool _didInitialize = false;
 
         // In general, let StackExchange.Redis handle most reconnects,
         // so limit the frequency of how often ForceReconnect() will
         // actually reconnect.
-        public static TimeSpan ReconnectMinFrequency => TimeSpan.FromSeconds(60);
+        public static TimeSpan ReconnectMinInterval => TimeSpan.FromSeconds(60);
 
         // If errors continue for longer than the below threshold, then the
         // multiplexer seems to not be reconnecting, so ForceReconnect() will
         // re-create the multiplexer.
         public static TimeSpan ReconnectErrorThreshold => TimeSpan.FromSeconds(30);
 
+        public static TimeSpan RestartConnectionTimeout => TimeSpan.FromSeconds(15);
+
         public static int RetryMaxAttempts => 5;
 
-        private static Lazy<ConnectionMultiplexer> lazyConnection = CreateConnection();
+        public static ConnectionMultiplexer Connection { get { return _connection; } }
 
-        public static ConnectionMultiplexer Connection
+        private static async Task InitializeAsync()
         {
-            get
+            if (_didInitialize)
             {
-                return lazyConnection.Value;
+                throw new InvalidOperationException("Cannot initialize more than once.");
             }
+
+            _connection = await CreateConnectionAsync();
+            _didInitialize = true;
+
         }
 
-        private static Lazy<ConnectionMultiplexer> CreateConnection()
+        // This method may return null if it fails to acquire the semaphore in time.
+        // Use the return value to update the "connection" field
+        private static async Task<ConnectionMultiplexer> CreateConnectionAsync()
         {
-            return new Lazy<ConnectionMultiplexer>(() =>
+            if (_connection != null)
             {
-                string cacheConnection = ConfigurationManager.AppSettings["CacheConnection"].ToString();
-                return ConnectionMultiplexer.Connect(cacheConnection);
-            });
-        }
-
-        private static void CloseConnection(Lazy<ConnectionMultiplexer> oldConnection)
-        {
-            if (oldConnection == null)
-                return;
+                // If we already have a good connection, let's re-use it
+                return _connection;
+            }
 
             try
             {
-                oldConnection.Value.Close();
+                await _initSemaphore.WaitAsync(RestartConnectionTimeout);
+            }
+            catch
+            {
+                // We failed to enter the semaphore in the given amount of time. Connection will either be null, or have a value that was created by another thread.
+                return _connection;
+            }
+
+            // We entered the semaphore successfully.
+            try
+            {
+                if (_connection != null)
+                {
+                    // Another thread must have finished creating a new connection while we were waiting to enter the semaphore. Let's use it
+                    return _connection;
+                }
+
+                // Otherwise, we really need to create a new connection.
+                string cacheConnection = ConfigurationManager.AppSettings["CacheConnection"].ToString();
+                return await ConnectionMultiplexer.ConnectAsync(cacheConnection);
+            }
+            finally
+            {
+                _initSemaphore.Release();
+            }
+        }
+
+        private static async Task CloseConnectionAsync(ConnectionMultiplexer oldConnection)
+        {
+            if (oldConnection == null)
+            {
+                return;
+            }
+            try
+            {
+                await oldConnection.CloseAsync();
             }
             catch (Exception)
             {
-                // Example error condition: if accessing oldConnection.Value causes a connection attempt and that fails.
+                // Ignore any errors from the oldConnection
             }
         }
 
         /// <summary>
         /// Force a new ConnectionMultiplexer to be created.
         /// NOTES:
-        ///     1. Users of the ConnectionMultiplexer MUST handle ObjectDisposedExceptions, which can now happen as a result of calling ForceReconnect().
-        ///     2. Don't call ForceReconnect for Timeouts, just for RedisConnectionExceptions or SocketExceptions.
-        ///     3. Call this method every time you see a connection exception. The code will:
+        ///     1. Users of the ConnectionMultiplexer MUST handle ObjectDisposedExceptions, which can now happen as a result of calling ForceReconnectAsync().
+        ///     2. Call ForceReconnectAsync() for RedisConnectionExceptions and RedisSocketExceptions. You can also call it for RedisTimeoutExceptions,
+        ///         but only if you're using generous ReconnectMinInterval and ReconnectErrorThreshold. Otherwise, establishing new connections can cause
+        ///         a cascade failure on a server that's timing out because it's already overloaded.
+        ///     3. The code will:
         ///         a. wait to reconnect for at least the "ReconnectErrorThreshold" time of repeated errors before actually reconnecting
-        ///         b. not reconnect more frequently than configured in "ReconnectMinFrequency"
+        ///         b. not reconnect more frequently than configured in "ReconnectMinInterval"
         /// </summary>
-        public static void ForceReconnect()
+        public static async Task ForceReconnectAsync()
         {
             var utcNow = DateTimeOffset.UtcNow;
-            long previousTicks = Interlocked.Read(ref lastReconnectTicks);
+            long previousTicks = Interlocked.Read(ref _lastReconnectTicks);
             var previousReconnectTime = new DateTimeOffset(previousTicks, TimeSpan.Zero);
             TimeSpan elapsedSinceLastReconnect = utcNow - previousReconnectTime;
 
-            // If multiple threads call ForceReconnect at the same time, we only want to honor one of them.
-            if (elapsedSinceLastReconnect < ReconnectMinFrequency)
+            // If multiple threads call ForceReconnectAsync at the same time, we only want to honor one of them.
+            if (elapsedSinceLastReconnect < ReconnectMinInterval)
+            {
                 return;
+            }
 
-            lock (reconnectLock)
+            try
+            {
+                await _reconnectSemaphore.WaitAsync(RestartConnectionTimeout);
+            }
+            catch
+            {
+                // If we fail to enter the semaphore, then it is possible that another thread has already done so.
+                // ForceReconnectAsync() can be retried while connectivity problems persist.
+                return;
+            }
+
+            try
             {
                 utcNow = DateTimeOffset.UtcNow;
                 elapsedSinceLastReconnect = utcNow - previousReconnectTime;
 
-                if (firstErrorTime == DateTimeOffset.MinValue)
+                if (_firstErrorTime == DateTimeOffset.MinValue)
                 {
                     // We haven't seen an error since last reconnect, so set initial values.
-                    firstErrorTime = utcNow;
-                    previousErrorTime = utcNow;
+                    _firstErrorTime = utcNow;
+                    _previousErrorTime = utcNow;
                     return;
                 }
 
-                if (elapsedSinceLastReconnect < ReconnectMinFrequency)
+                if (elapsedSinceLastReconnect < ReconnectMinInterval)
+                {
                     return; // Some other thread made it through the check and the lock, so nothing to do.
+                }
 
-                TimeSpan elapsedSinceFirstError = utcNow - firstErrorTime;
-                TimeSpan elapsedSinceMostRecentError = utcNow - previousErrorTime;
+                TimeSpan elapsedSinceFirstError = utcNow - _firstErrorTime;
+                TimeSpan elapsedSinceMostRecentError = utcNow - _previousErrorTime;
 
                 bool shouldReconnect =
                     elapsedSinceFirstError >= ReconnectErrorThreshold // Make sure we gave the multiplexer enough time to reconnect on its own if it could.
                     && elapsedSinceMostRecentError <= ReconnectErrorThreshold; // Make sure we aren't working on stale data (e.g. if there was a gap in errors, don't reconnect yet).
 
                 // Update the previousErrorTime timestamp to be now (e.g. this reconnect request).
-                previousErrorTime = utcNow;
+                _previousErrorTime = utcNow;
 
                 if (!shouldReconnect)
+                {
                     return;
+                }
 
-                firstErrorTime = DateTimeOffset.MinValue;
-                previousErrorTime = DateTimeOffset.MinValue;
+                _firstErrorTime = DateTimeOffset.MinValue;
+                _previousErrorTime = DateTimeOffset.MinValue;
 
-                Lazy<ConnectionMultiplexer> oldConnection = lazyConnection;
-                CloseConnection(oldConnection);
-                lazyConnection = CreateConnection();
-                Interlocked.Exchange(ref lastReconnectTicks, utcNow.UtcTicks);
+                ConnectionMultiplexer oldConnection = _connection;
+                await CloseConnectionAsync(oldConnection);
+                _connection = null;
+                _connection = await CreateConnectionAsync();
+                Interlocked.Exchange(ref _lastReconnectTicks, utcNow.UtcTicks);
+            }
+            finally
+            {
+                _reconnectSemaphore.Release();
             }
         }
 
         // In real applications, consider using a framework such as
         // Polly to make it easier to customize the retry approach.
-        private static T BasicRetry<T>(Func<T> func)
+        private static async Task<T> BasicRetryAsync<T>(Func<T> func)
         {
             int reconnectRetry = 0;
             int disposedRetry = 0;
@@ -152,7 +218,7 @@ namespace Redistest
                     reconnectRetry++;
                     if (reconnectRetry > RetryMaxAttempts)
                         throw;
-                    ForceReconnect();
+                    await ForceReconnectAsync();
                 }
                 catch (ObjectDisposedException)
                 {
@@ -163,24 +229,26 @@ namespace Redistest
             }
         }
 
-        public static IDatabase GetDatabase()
+        public static Task<IDatabase> GetDatabaseAsync()
         {
-            return BasicRetry(() => Connection.GetDatabase());
+            return BasicRetryAsync(() => Connection.GetDatabase());
         }
 
-        public static System.Net.EndPoint[] GetEndPoints()
+        public static Task<System.Net.EndPoint[]> GetEndPointsAsync()
         {
-            return BasicRetry(() => Connection.GetEndPoints());
+            return BasicRetryAsync(() => Connection.GetEndPoints());
         }
 
-        public static IServer GetServer(string host, int port)
+        public static Task<IServer> GetServerAsync(string host, int port)
         {
-            return BasicRetry(() => Connection.GetServer(host, port));
+            return BasicRetryAsync(() => Connection.GetServer(host, port));
         }
 
-        static void Main(string[] args)
+        static async Task Main(string[] args)
         {
-            IDatabase cache = GetDatabase();
+            await InitializeAsync();
+
+            IDatabase cache = await GetDatabaseAsync();
 
             // Perform cache operations using the cache object...
 
@@ -207,9 +275,9 @@ namespace Redistest
             // Note that this requires allowAdmin=true in the connection string
             cacheCommand = "CLIENT LIST";
             Console.WriteLine("\nCache command  : " + cacheCommand);
-            var endpoint = (System.Net.DnsEndPoint)GetEndPoints()[0];
-            IServer server = GetServer(endpoint.Host, endpoint.Port);
-            ClientInfo[] clients = server.ClientList();
+            var endpoint = (System.Net.DnsEndPoint)(await GetEndPointsAsync())[0];
+            IServer server = await GetServerAsync(endpoint.Host, endpoint.Port);
+            ClientInfo[] clients = await server.ClientListAsync();
 
             Console.WriteLine("Cache response :");
             foreach (ClientInfo client in clients)
@@ -229,7 +297,7 @@ namespace Redistest
             Console.WriteLine("\tEmployee.Id   : " + e007FromCache.Id);
             Console.WriteLine("\tEmployee.Age  : " + e007FromCache.Age + "\n");
 
-            CloseConnection(lazyConnection);
+            await CloseConnectionAsync(_connection);
         }
     }
 }


### PR DESCRIPTION
## Purpose
It's been pointed out to us by several sources that the Lazy<T> pattern can lead to lock contention & thread starvation. To avoid this, I've replaced this pattern with an explicit singleton initialization. I also updated the code to use SemaphoreSlim instead of Locks for performance, and to take advantage of the async overloads from StackExchange.Redis. 

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Other Information
N/A