### PR TITLE
Unsafe async call to CloseAsync

### DIFF
--- a/quickstart/aspnet/ContosoTeamStats/RedisConnection.cs
+++ b/quickstart/aspnet/ContosoTeamStats/RedisConnection.cs
@@ -146,7 +146,7 @@ namespace ContosoTeamStats
                 ConnectionMultiplexer oldConnection = _connection;
                 try
                 {
-                    await oldConnection?.CloseAsync();
+                    await (oldConnection?.CloseAsync() ?? Task.CompletedTask);
                 }
                 catch (Exception)
                 {


### PR DESCRIPTION
The null conditional operator on an async call needs to have somewhere to go when the target is null.

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* ...

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Other Information
<!-- Add any other helpful information that may be needed here. -->