### PR TITLE
fix bundle issue and NullReferenceException

### DIFF
--- a/quickstart/aspnet-core/ContosoTeamStats/RedisConnection.cs
+++ b/quickstart/aspnet-core/ContosoTeamStats/RedisConnection.cs
@@ -143,14 +143,16 @@ namespace ContosoTeamStats
                 _firstErrorTime = DateTimeOffset.MinValue;
                 _previousErrorTime = DateTimeOffset.MinValue;
 
-                ConnectionMultiplexer oldConnection = _connection;
-                try
+                if (_connection != null)
                 {
-                    await oldConnection?.CloseAsync();
-                }
-                catch (Exception)
-                {
-                    // Ignore any errors from the oldConnection
+                    try
+                    {
+                        await _connection.CloseAsync();
+                    }
+                    catch
+                    {
+                        // Ignore any errors from the old connection
+                    }
                 }
 
                 Interlocked.Exchange(ref _connection, null);

--- a/quickstart/aspnet/ContosoTeamStats/App_Start/BundleConfig.cs
+++ b/quickstart/aspnet/ContosoTeamStats/App_Start/BundleConfig.cs
@@ -8,8 +8,10 @@ namespace ContosoTeamStats
         // For more information on bundling, visit https://go.microsoft.com/fwlink/?LinkId=301862
         public static void RegisterBundles(BundleCollection bundles)
         {
-            bundles.Add(new ScriptBundle("~/bundles/jquery").Include(
-                        "~/Scripts/jquery-{version}.js"));
+            var jqueryCdn = "https://ajax.aspnetcdn.com/ajax/jQuery/jquery-3.3.1.js";
+
+            bundles.Add(new ScriptBundle("~/bundles/jquery", jqueryCdn).Include(
+                        "~/Scripts/jquery-3.3.1.js"));
 
             bundles.Add(new ScriptBundle("~/bundles/bootstrap").Include(
                       "~/Scripts/bootstrap.js"));

--- a/quickstart/aspnet/ContosoTeamStats/App_Start/BundleConfig.cs
+++ b/quickstart/aspnet/ContosoTeamStats/App_Start/BundleConfig.cs
@@ -8,9 +8,8 @@ namespace ContosoTeamStats
         // For more information on bundling, visit https://go.microsoft.com/fwlink/?LinkId=301862
         public static void RegisterBundles(BundleCollection bundles)
         {
-            var jqueryCdn = "https://ajax.aspnetcdn.com/ajax/jQuery/jquery-3.3.1.js";
 
-            bundles.Add(new ScriptBundle("~/bundles/jquery", jqueryCdn).Include(
+            bundles.Add(new ScriptBundle("~/bundles/jquery", "https://ajax.aspnetcdn.com/ajax/jQuery/jquery-3.3.1.js"n).Include(
                         "~/Scripts/jquery-3.3.1.js"));
 
             bundles.Add(new ScriptBundle("~/bundles/bootstrap").Include(

--- a/quickstart/aspnet/ContosoTeamStats/App_Start/BundleConfig.cs
+++ b/quickstart/aspnet/ContosoTeamStats/App_Start/BundleConfig.cs
@@ -9,7 +9,7 @@ namespace ContosoTeamStats
         public static void RegisterBundles(BundleCollection bundles)
         {
 
-            bundles.Add(new ScriptBundle("~/bundles/jquery", "https://ajax.aspnetcdn.com/ajax/jQuery/jquery-3.3.1.js"n).Include(
+            bundles.Add(new ScriptBundle("~/bundles/jquery", "https://ajax.aspnetcdn.com/ajax/jQuery/jquery-3.3.1.js").Include(
                         "~/Scripts/jquery-3.3.1.js"));
 
             bundles.Add(new ScriptBundle("~/bundles/bootstrap").Include(

--- a/quickstart/aspnet/ContosoTeamStats/RedisConnection.cs
+++ b/quickstart/aspnet/ContosoTeamStats/RedisConnection.cs
@@ -155,7 +155,6 @@ namespace ContosoTeamStats
                     }
                 }
 
-
                 Interlocked.Exchange(ref _connection, null);
                 ConnectionMultiplexer newConnection = await ConnectionMultiplexer.ConnectAsync(_connectionString);
                 Interlocked.Exchange(ref _connection, newConnection);

--- a/quickstart/aspnet/ContosoTeamStats/RedisConnection.cs
+++ b/quickstart/aspnet/ContosoTeamStats/RedisConnection.cs
@@ -146,7 +146,10 @@ namespace ContosoTeamStats
                 ConnectionMultiplexer oldConnection = _connection;
                 try
                 {
-                    await oldConnection?.CloseAsync();
+                    if (oldConnection != null)
+                    {
+                        await oldConnection?.CloseAsync();
+                    }
                 }
                 catch (Exception)
                 {

--- a/quickstart/aspnet/ContosoTeamStats/RedisConnection.cs
+++ b/quickstart/aspnet/ContosoTeamStats/RedisConnection.cs
@@ -143,18 +143,18 @@ namespace ContosoTeamStats
                 _firstErrorTime = DateTimeOffset.MinValue;
                 _previousErrorTime = DateTimeOffset.MinValue;
 
-                ConnectionMultiplexer oldConnection = _connection;
-                try
+                if (_connection != null)
                 {
-                    if (oldConnection != null)
+                    try
                     {
-                        await oldConnection?.CloseAsync();
+                        await _connection.CloseAsync();
+                    }
+                    catch
+                    {
+                        // Ignore any errors from the old connection
                     }
                 }
-                catch (Exception)
-                {
-                    // Ignore any errors from the oldConnection
-                }
+
 
                 Interlocked.Exchange(ref _connection, null);
                 ConnectionMultiplexer newConnection = await ConnectionMultiplexer.ConnectAsync(_connectionString);

--- a/quickstart/dotnet-core/RedisConnection.cs
+++ b/quickstart/dotnet-core/RedisConnection.cs
@@ -143,14 +143,16 @@ namespace Redistest
                 _firstErrorTime = DateTimeOffset.MinValue;
                 _previousErrorTime = DateTimeOffset.MinValue;
 
-                ConnectionMultiplexer oldConnection = _connection;
-                try
+                if (_connection != null)
                 {
-                    await oldConnection?.CloseAsync();
-                }
-                catch (Exception)
-                {
-                    // Ignore any errors from the oldConnection
+                    try
+                    {
+                        await _connection.CloseAsync();
+                    }
+                    catch
+                    {
+                        // Ignore any errors from the old connection
+                    }
                 }
 
                 Interlocked.Exchange(ref _connection, null);

--- a/quickstart/dotnet/Redistest/RedisConnection.cs
+++ b/quickstart/dotnet/Redistest/RedisConnection.cs
@@ -143,14 +143,16 @@ namespace Redistest
                 _firstErrorTime = DateTimeOffset.MinValue;
                 _previousErrorTime = DateTimeOffset.MinValue;
 
-                ConnectionMultiplexer oldConnection = _connection;
-                try
+                if (_connection != null)
                 {
-                    await oldConnection?.CloseAsync();
-                }
-                catch (Exception)
-                {
-                    // Ignore any errors from the oldConnection
+                    try
+                    {
+                        await _connection.CloseAsync();
+                    }
+                    catch
+                    {
+                        // Ignore any errors from the old connection
+                    }
                 }
 
                 Interlocked.Exchange(ref _connection, null);


### PR DESCRIPTION
Hi All,

Can you please advise if the samples can work correctly. Already, for ASP sample, in VS 2022 after struggling with missing bundles/scripts not found virtual directory, it fails on the line 149 of
azure-cache-redis-samples of redisConnection.cs
I followed the instructions for "cache-web-app-aspnet-core-howto" it builds and run then when clicking on "Azure Cache for Redis Test", I get

[azure-cache-redis-samples/quickstart/aspnet at main · Azure-Samples/azure-cache-redis-samples · GitHub](https://nam06.safelinks.protection.outlook.com/?url=https:%2f%2fgithub.com%2fAzure-Samples%2fazure-cache-redis-samples%2ftree%2fmain%2fquickstart%2faspnet&data=05%7c01%7cphilon%40exchange.microsoft.com%7ceb369e610695400af4bf08da59ddf500%7c72f988bf86f141af91ab2d7cd011db47%7c1%7c0%7c637921107120967020%7cUnknown%7cTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7c3000%7c%7c%7c&sdata=gjp7avRTzae6StbIC%2BX2xF%2Bux445anaarHCKJKSxkMA%3D&reserved=0)

In the ASP sample, execution jumps from line

await redisConnection.ForceReconnectAsync(initializing: true);

right away to

await oldConnection?.CloseAsync();

with the following error on line 149 :

System.NullReferenceException
HResult=0x80004003
Message=Object reference not set to an instance of an object.
Source=ContosoTeamStats
StackTrace:
at ContosoTeamStats.RedisConnection.<ForceReconnectAsync>d__14.MoveNext() in C:\Projects\AzureDevOpsProjects\Redis\aspnet\ContosoTeamStats\RedisConnection.cs:line 149