### PR TITLE
ForceReconnect sample code missing catch for ObjectDisposedException

### DIFF
--- a/quickstart/aspnet-core/ContosoTeamStats/RedisConnection.cs
+++ b/quickstart/aspnet-core/ContosoTeamStats/RedisConnection.cs
@@ -67,7 +67,7 @@ namespace ContosoTeamStats
                     {
                         await ForceReconnectAsync();
                     }
-                    catch (ObjectDisposedException) {
+                    catch (Exception) {
                         return await func(_database);
                     }
                 }

--- a/quickstart/aspnet-core/ContosoTeamStats/RedisConnection.cs
+++ b/quickstart/aspnet-core/ContosoTeamStats/RedisConnection.cs
@@ -55,7 +55,7 @@ namespace ContosoTeamStats
                 {
                     return await func(_database);
                 }
-                catch (Exception ex) when (ex is RedisConnectionException || ex is SocketException)
+                catch (Exception ex) when (ex is RedisConnectionException || ex is SocketException || ex is ObjectDisposedException)
                 {
                     reconnectRetry++;
                     if (reconnectRetry > RetryMaxAttempts)
@@ -67,9 +67,11 @@ namespace ContosoTeamStats
                     {
                         await ForceReconnectAsync();
                     }
-                    catch (ObjectDisposedException) { }
+                    catch (ObjectDisposedException) {
+                        return await func(_database);
+                    }
                 }
-                catch (ObjectDisposedException) {}
+                catch (Exception) {}
             }
         }
 

--- a/quickstart/aspnet-core/ContosoTeamStats/RedisConnection.cs
+++ b/quickstart/aspnet-core/ContosoTeamStats/RedisConnection.cs
@@ -69,6 +69,7 @@ namespace ContosoTeamStats
                     }
                     catch (ObjectDisposedException) { }
                 }
+                catch (ObjectDisposedException) {}
             }
         }
 

--- a/quickstart/aspnet-core/ContosoTeamStats/RedisConnection.cs
+++ b/quickstart/aspnet-core/ContosoTeamStats/RedisConnection.cs
@@ -67,11 +67,10 @@ namespace ContosoTeamStats
                     {
                         await ForceReconnectAsync();
                     }
-                    catch (Exception) {
-                        return await func(_database);
-                    }
+                    catch (ObjectDisposedException) { }
+
+                    return await func(_database);
                 }
-                catch (Exception) {}
             }
         }
 

--- a/quickstart/aspnet-core/ContosoTeamStats/libman.json
+++ b/quickstart/aspnet-core/ContosoTeamStats/libman.json
@@ -3,7 +3,7 @@
   "defaultProvider": "cdnjs",
   "libraries": [
     {
-      "library": "jquery@3.3.1",
+      "library": "jquery@3.6.0",
       "destination": "wwwroot/lib/jquery/",
       "files": [
         "jquery.min.js",
@@ -12,7 +12,7 @@
       ]
     },
     {
-      "library": "twitter-bootstrap@4.3.1",
+      "library": "twitter-bootstrap@5.1.3",
       "destination": "wwwroot/lib/bootstrap/"
     },
     {
@@ -20,7 +20,7 @@
       "destination": "wwwroot/jquery-validation-unobtrusive/"
     },
     {
-      "library": "jquery-validate@1.17.0",
+      "library": "jquery-validate@1.19.4",
       "destination": "wwwroot/jquery-validate/",
       "files": [
         "jquery.validate.min.js",

--- a/quickstart/aspnet/ContosoTeamStats/App_Start/BundleConfig.cs
+++ b/quickstart/aspnet/ContosoTeamStats/App_Start/BundleConfig.cs
@@ -10,7 +10,7 @@ namespace ContosoTeamStats
         {
 
             bundles.Add(new ScriptBundle("~/bundles/jquery").Include(
-                        "~/Scripts/jquery-{$version}.js"));
+                        "~/Scripts/jquery-{version}.js"));
 
             bundles.Add(new ScriptBundle("~/bundles/bootstrap").Include(
                       "~/Scripts/bootstrap.js"));

--- a/quickstart/aspnet/ContosoTeamStats/RedisConnection.cs
+++ b/quickstart/aspnet/ContosoTeamStats/RedisConnection.cs
@@ -67,7 +67,7 @@ namespace ContosoTeamStats
                     {
                         await ForceReconnectAsync();
                     }
-                    catch (ObjectDisposedException) {
+                    catch (Exception) {
                         return await func(_database);
                     }
                 }

--- a/quickstart/aspnet/ContosoTeamStats/RedisConnection.cs
+++ b/quickstart/aspnet/ContosoTeamStats/RedisConnection.cs
@@ -55,7 +55,7 @@ namespace ContosoTeamStats
                 {
                     return await func(_database);
                 }
-                catch (Exception ex) when (ex is RedisConnectionException || ex is SocketException)
+                catch (Exception ex) when (ex is RedisConnectionException || ex is SocketException || ex is ObjectDisposedException)
                 {
                     reconnectRetry++;
                     if (reconnectRetry > RetryMaxAttempts)
@@ -67,9 +67,11 @@ namespace ContosoTeamStats
                     {
                         await ForceReconnectAsync();
                     }
-                    catch (ObjectDisposedException) { }
+                    catch (ObjectDisposedException) {
+                        return await func(_database);
+                    }
                 }
-                catch (ObjectDisposedException) {}
+                catch (Exception) {}
             }
         }
 

--- a/quickstart/aspnet/ContosoTeamStats/RedisConnection.cs
+++ b/quickstart/aspnet/ContosoTeamStats/RedisConnection.cs
@@ -69,6 +69,7 @@ namespace ContosoTeamStats
                     }
                     catch (ObjectDisposedException) { }
                 }
+                catch (ObjectDisposedException) {}
             }
         }
 

--- a/quickstart/aspnet/ContosoTeamStats/RedisConnection.cs
+++ b/quickstart/aspnet/ContosoTeamStats/RedisConnection.cs
@@ -67,11 +67,10 @@ namespace ContosoTeamStats
                     {
                         await ForceReconnectAsync();
                     }
-                    catch (Exception) {
-                        return await func(_database);
-                    }
+                    catch (ObjectDisposedException) { }
+
+                    return await func(_database);
                 }
-                catch (Exception) {}
             }
         }
 

--- a/quickstart/dotnet-core/RedisConnection.cs
+++ b/quickstart/dotnet-core/RedisConnection.cs
@@ -55,7 +55,7 @@ namespace Redistest
                 {
                     return await func(_database);
                 }
-                catch (Exception ex) when (ex is RedisConnectionException || ex is SocketException)
+                catch (Exception ex) when (ex is RedisConnectionException || ex is SocketException || ex is ObjectDisposedException)
                 {
                     reconnectRetry++;
                     if (reconnectRetry > RetryMaxAttempts)
@@ -67,9 +67,11 @@ namespace Redistest
                     {
                         await ForceReconnectAsync();
                     }
-                    catch (ObjectDisposedException) { }
+                    catch (ObjectDisposedException) {
+                        return await func(_database);
+                    }
                 }
-                catch (ObjectDisposedException) {}
+                catch (Exception) {}
             }
         }
 

--- a/quickstart/dotnet-core/RedisConnection.cs
+++ b/quickstart/dotnet-core/RedisConnection.cs
@@ -69,6 +69,7 @@ namespace Redistest
                     }
                     catch (ObjectDisposedException) { }
                 }
+                catch (ObjectDisposedException) {}
             }
         }
 

--- a/quickstart/dotnet-core/RedisConnection.cs
+++ b/quickstart/dotnet-core/RedisConnection.cs
@@ -67,11 +67,10 @@ namespace Redistest
                     {
                         await ForceReconnectAsync();
                     }
-                    catch (Exception) {
-                        return await func(_database);
-                    }
+                    catch (ObjectDisposedException) { }
+
+                    return await func(_database);
                 }
-                catch (Exception) {}
             }
         }
 

--- a/quickstart/dotnet-core/RedisConnection.cs
+++ b/quickstart/dotnet-core/RedisConnection.cs
@@ -67,7 +67,7 @@ namespace Redistest
                     {
                         await ForceReconnectAsync();
                     }
-                    catch (ObjectDisposedException) {
+                    catch (Exception) {
                         return await func(_database);
                     }
                 }

--- a/quickstart/dotnet/Redistest/RedisConnection.cs
+++ b/quickstart/dotnet/Redistest/RedisConnection.cs
@@ -55,7 +55,7 @@ namespace Redistest
                 {
                     return await func(_database);
                 }
-                catch (Exception ex) when (ex is RedisConnectionException || ex is SocketException)
+                catch (Exception ex) when (ex is RedisConnectionException || ex is SocketException || ex is ObjectDisposedException)
                 {
                     reconnectRetry++;
                     if (reconnectRetry > RetryMaxAttempts)
@@ -67,9 +67,11 @@ namespace Redistest
                     {
                         await ForceReconnectAsync();
                     }
-                    catch (ObjectDisposedException) { }
+                    catch (ObjectDisposedException) {
+                        return await func(_database);
+                    }
                 }
-                catch (ObjectDisposedException) {}
+                catch (Exception) {}
             }
         }
 

--- a/quickstart/dotnet/Redistest/RedisConnection.cs
+++ b/quickstart/dotnet/Redistest/RedisConnection.cs
@@ -69,6 +69,7 @@ namespace Redistest
                     }
                     catch (ObjectDisposedException) { }
                 }
+                catch (ObjectDisposedException) {}
             }
         }
 

--- a/quickstart/dotnet/Redistest/RedisConnection.cs
+++ b/quickstart/dotnet/Redistest/RedisConnection.cs
@@ -67,11 +67,10 @@ namespace Redistest
                     {
                         await ForceReconnectAsync();
                     }
-                    catch (Exception) {
-                        return await func(_database);
-                    }
+                    catch (ObjectDisposedException) { }
+
+                    return await func(_database);
                 }
-                catch (Exception) {}
             }
         }
 

--- a/quickstart/dotnet/Redistest/RedisConnection.cs
+++ b/quickstart/dotnet/Redistest/RedisConnection.cs
@@ -67,7 +67,7 @@ namespace Redistest
                     {
                         await ForceReconnectAsync();
                     }
-                    catch (ObjectDisposedException) {
+                    catch (Exception) {
                         return await func(_database);
                     }
                 }


### PR DESCRIPTION
Looks like object disposed error still needs to be handled by caller? Should that error be handled in the [BasicRetry catch block](https://github.com/Azure-Samples/azure-cache-redis-samples/blob/main/quickstart/aspnet-core/ContosoTeamStats/RedisConnection.cs#L58)?

I see that the ForceReconnectAsync is handling ObjectDIsposedException but I think that error can happen in the caller on the IDatabase too?