### PR TITLE
Remove 'aspnet' from product list in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ name: Azure Cache for Redis samples
 description: Learn how to use Azure Cache for Redis to have access to a secure, dedicated cache that is accessible from any application within Azure.
 products:
 - azure
-- aspnet
 - aspnet-core
 - dotnet
 - azure-cache-redis


### PR DESCRIPTION
The `aspnet` value is deprecated.

https://learn.microsoft.com/en-us/help/platform/metadata-taxonomies/product#planned-for-deprecation