### PR TITLE
Remove page_type from README.md

### DIFF
--- a/quickstart/aspnet/README.md
+++ b/quickstart/aspnet/README.md
@@ -1,5 +1,4 @@
 ---
-page_type: sample
 languages:
 - aspx-csharp
 - csharp


### PR DESCRIPTION
Removing metadata that makes this seemingly deprecated sample appear in the Learn samples browser. The corresponding article was removed in https://github.com/MicrosoftDocs/azure-docs-pr/pull/311155.
